### PR TITLE
Merging LWT into HA discovery

### DIFF
--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -442,7 +442,7 @@ class MQTTThread(weewx.restx.RESTThread):
             pad = "%032x" % random.getrandbits(128)
             client_id = 'weewx_%s' % pad[:8]
         mc = mqtt.Client(client_id=client_id)
-        mc.will_set(self.topic + '/available', payload='offline', retain=True)
+        mc.will_set(self.topic + '/availability', payload='offline', retain=True)
         url = urlparse(self.server_url)
         if url.username is not None and url.password is not None:
             mc.username_pw_set(url.username, url.password)
@@ -457,7 +457,7 @@ class MQTTThread(weewx.restx.RESTThread):
                     (_obfuscate_password(self.server_url), str(e)))
             self.mc = None
             return
-        mc.publish(self.topic + '/available', payload='online', retain=True)
+        mc.publish(self.topic + '/availability', payload='online', retain=True)
         mc.loop_start()
         loginf('client established for %s' %
                _obfuscate_password(self.server_url))

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -434,6 +434,7 @@ class MQTTThread(weewx.restx.RESTThread):
 
     def get_mqtt_client(self):
         if self.mc:
+            mc.publish(self.topic + '/availability', payload='online', retain=True)
             return
         if time.time() - self.mc_try_time < self.retry_wait:
             return

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -434,7 +434,7 @@ class MQTTThread(weewx.restx.RESTThread):
 
     def get_mqtt_client(self):
         if self.mc:
-            mc.publish(self.topic + '/availability', payload='online', retain=True)
+            self.mc.publish(self.topic + '/availability', payload='online', retain=True)
             return
         if time.time() - self.mc_try_time < self.retry_wait:
             return

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -442,7 +442,7 @@ class MQTTThread(weewx.restx.RESTThread):
             pad = "%032x" % random.getrandbits(128)
             client_id = 'weewx_%s' % pad[:8]
         mc = mqtt.Client(client_id=client_id)
-        mc.will_set(self.topic + '/lwt', payload='offline', retain=True)
+        mc.will_set(self.topic + '/available', payload='offline', retain=True)
         url = urlparse(self.server_url)
         if url.username is not None and url.password is not None:
             mc.username_pw_set(url.username, url.password)
@@ -457,7 +457,7 @@ class MQTTThread(weewx.restx.RESTThread):
                     (_obfuscate_password(self.server_url), str(e)))
             self.mc = None
             return
-        mc.publish(self.topic + '/lwt', payload='online', retain=True)
+        mc.publish(self.topic + '/available', payload='online', retain=True)
         mc.loop_start()
         loginf('client established for %s' %
                _obfuscate_password(self.server_url))

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -442,6 +442,7 @@ class MQTTThread(weewx.restx.RESTThread):
             pad = "%032x" % random.getrandbits(128)
             client_id = 'weewx_%s' % pad[:8]
         mc = mqtt.Client(client_id=client_id)
+        mc.will_set(self.topic + '/lwt', payload='offline', retain=True)
         url = urlparse(self.server_url)
         if url.username is not None and url.password is not None:
             mc.username_pw_set(url.username, url.password)
@@ -456,6 +457,7 @@ class MQTTThread(weewx.restx.RESTThread):
                     (_obfuscate_password(self.server_url), str(e)))
             self.mc = None
             return
+        mc.publish(self.topic + '/lwt', payload='online', retain=True)
         mc.loop_start()
         loginf('client established for %s' %
                _obfuscate_password(self.server_url))


### PR DESCRIPTION
In my opinion LWT is concept really useful for automation systems -i.e. HomeAssistant or in other live data solutions - i.e. skin [belchertown](https://github.com/poblabs/weewx-belchertown). Out of that scenario I don't see a reason for weewx-mqtt to set last will. @ThomDietrich do you agree? 
However in HA it is a big plus to have it as option. I would suggest to make it an config option(Fixes  [21)](https://github.com/matthewwall/weewx-mqtt/issues/21#issue-892764149) and set it to True if ha_discovery is true. Then we can have a device_tracker for weewx and availability status for the sensors. 

If you agree I can merge the two PR in one