### PR TITLE
Throttle discovery

### DIFF
--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -664,7 +664,7 @@ class MQTTThread(weewx.restx.RESTThread):
                 if sensor[key]['type'] == 'timestamp':
                     conf['value_template'] = "{{ value | int | as_datetime }}"
                 if sensor[key]['unit'] == 'inHg':
-                    conf['value_template'] = "{{ value_json." + key + "  | float | round(2) }}"
+                    conf['value_template'] = "{{ value | float | round(2) }}"
                 else:
                     conf['value_template'] = "{{ value | float | round(1) }}"
             conf['availability_topic'] = self.topic + '/availability' 

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -655,7 +655,7 @@ class MQTTThread(weewx.restx.RESTThread):
                 conf['state_topic'] = self.topic + '/loop'
                 if sensor[key]['type'] == 'timestamp':
                     conf['value_template'] = "{{ value_json." + key + " | int | as_datetime }}"
-                if sensor[key]['unit'] == 'inHg':
+                elif sensor[key]['unit'] == 'inHg':
                     conf['value_template'] = "{{ value_json." + key + "  | float | round(2) }}"
                 else:
                     conf['value_template'] = "{{ value_json." + key + "  | float | round(1) }}"
@@ -663,7 +663,7 @@ class MQTTThread(weewx.restx.RESTThread):
                 conf['state_topic'] = self.topic + '/' + key
                 if sensor[key]['type'] == 'timestamp':
                     conf['value_template'] = "{{ value | int | as_datetime }}"
-                if sensor[key]['unit'] == 'inHg':
+                elif sensor[key]['unit'] == 'inHg':
                     conf['value_template'] = "{{ value | float | round(2) }}"
                 else:
                     conf['value_template'] = "{{ value | float | round(1) }}"

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -631,7 +631,7 @@ class MQTTThread(weewx.restx.RESTThread):
             sensor[f]['type'] = HA_SENSOR_TYPE.get(unit_type, unit_type)
             sensor[f]['unit'] = HA_SENSOR_UNIT.get(unit_type, unit_type)
         return sensor
-   
+
     def ha_discovery_send(self, data, sensor, topic_mode):
         if self.ha_device_name is not None:
             device_tracker = dict()

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -191,7 +191,6 @@ UNIT_REDUCTIONS = {
     'degree_F': 'F',
     'degree_C': 'C',
     'inch': 'in',
-    'inch': 'in',
     'mile_per_hour': 'mph',
     'mile_per_hour2': 'mph',
     'km_per_hour': 'kph',
@@ -632,7 +631,7 @@ class MQTTThread(weewx.restx.RESTThread):
             sensor[f]['type'] = HA_SENSOR_TYPE.get(unit_type, unit_type)
             sensor[f]['unit'] = HA_SENSOR_UNIT.get(unit_type, unit_type)
         return sensor
- 
+   
     def ha_discovery_send(self, data, sensor, topic_mode):
         if self.ha_device_name is not None:
             device_tracker = dict()

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -191,6 +191,7 @@ UNIT_REDUCTIONS = {
     'degree_F': 'F',
     'degree_C': 'C',
     'inch': 'in',
+    'inch': 'in',
     'mile_per_hour': 'mph',
     'mile_per_hour2': 'mph',
     'km_per_hour': 'kph',
@@ -211,7 +212,8 @@ UNIT_REDUCTIONS = {
 HA_SENSOR_TYPE = {
     'degree_F': 'temperature',
     'degree_C': 'temperature',
-    'mbar': 'pressure',	
+    'mbar': 'atmospheric_pressure',
+    'inHg': 'atmospheric_pressure',
     'inch': 'precipitation',
     'cm': 'precipitation',
     'mm': 'precipitation',
@@ -223,6 +225,7 @@ HA_SENSOR_TYPE = {
     'mile_per_hour': 'wind_speed',
     'mile_per_hour2': 'wind_speed',
     'mm_per_hour': 'precipitation_intensity',
+    'inch_per_hour': 'precipitation_intensity',
     'cm_per_hour': 'precipitation_intensity',
     'cm_per_hour2': 'precipitation_intensity',   
     'km_per_hour': 'precipitation_intensity',
@@ -253,6 +256,7 @@ HA_SENSOR_UNIT = {
     'hour': 'h',
     'mile_per_hour': 'mph',
     'mile_per_hour2': 'mph',
+    'inch_per_hour': 'in/h',
     'mm_per_hour': 'mm/h',
     'mm_per_hour2': 'mm/h',
     'cm_per_hour': 'cm/h',
@@ -651,12 +655,16 @@ class MQTTThread(weewx.restx.RESTThread):
                 conf['state_topic'] = self.topic + '/loop'
                 if sensor[key]['type'] == 'timestamp':
                     conf['value_template'] = "{{ value_json." + key + " | int | as_datetime }}"
+                if sensor[key]['unit'] == 'inHg':
+                    conf['value_template'] = "{{ value_json." + key + "  | float | round(2) }}"
                 else:
                     conf['value_template'] = "{{ value_json." + key + "  | float | round(1) }}"
             elif topic_mode == 'individual':
                 conf['state_topic'] = self.topic + '/' + key
                 if sensor[key]['type'] == 'timestamp':
                     conf['value_template'] = "{{ value | int | as_datetime }}"
+                if sensor[key]['unit'] == 'inHg':
+                    conf['value_template'] = "{{ value_json." + key + "  | float | round(2) }}"
                 else:
                     conf['value_template'] = "{{ value | float | round(1) }}"
             conf['availability_topic'] = self.topic + '/availability' 


### PR DESCRIPTION
Since I was running into issues with logging and the frequency of the discovery topic updates I set it to only update once per minute. Technically it could probably be set to only update the first time the loop is run, but in case the broker resets or somehow loses the topic this will refresh it.